### PR TITLE
travis CI test for ipynb files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - "3.6"
+cache: pip
+install:
+  - pip install nbformat
+script: python3 test.py

--- a/test.py
+++ b/test.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# This tests if the .ipynb notebooks are valid
+import os
+import sys
+from nbformat import validate
+import glob
+import json
+
+curdir = os.path.dirname(os.path.abspath(__file__))
+os.chdir(curdir)
+
+fail = False
+for ipynb in glob.iglob('**/*.ipynb', recursive=True):
+    fn = os.path.join(curdir, ipynb)
+    try:
+        data = json.load(open(fn, 'r'))
+        validate(data)
+    except:
+        print("validation failed: {}".format(ipynb))
+        fail = True
+if fail:
+    sys.exit(1)
+else:
+    sys.exit(0)
+
+

--- a/test.py
+++ b/test.py
@@ -18,9 +18,13 @@ for ipynb in glob.iglob('**/*.ipynb', recursive=True):
     except:
         print("validation failed: {}".format(ipynb))
         fail = True
+    else:
+        print("valid ipynb: {}".format(ipynb))
 if fail:
+    print("TESTS FAILED")
     sys.exit(1)
 else:
+    print("TESTS PASS")
     sys.exit(0)
 
 


### PR DESCRIPTION
Earlier today we noticed that some ipynb files were corrupt. Then, they don't work and it's confusing. This is a simple continuous integration test validating the ipynb files.

Confused? Well, it's easy. To get you started with this, simply goto https://travis-ci.org and use your github account. Then activate your `rbeezer/sla` repository there, it's a toggle button. That's all.

In the end, you will see build results like this one: https://travis-ci.org/haraldschilly/sla and when this test fails, you'll get emails... It even tells you about problems in pull requests before a merge :boom: 